### PR TITLE
github/build: Fix indentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,8 +74,8 @@ jobs:
         with:
           node-version: 12.x
       - run: npx yarn bootstrap
-      - working-directory: example
-        uses: chromaui/action@v1
-          with:
-            token: ${{ secrets.GITHUB_TOKEN }}
-            projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+        working-directory: example
+      - uses: chromaui/action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,7 @@ jobs:
         with:
           node-version: 12.x
       - run: npx yarn bootstrap
+        working-directory: ../
       - uses: chromaui/action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,13 +68,15 @@ jobs:
     needs: [test]
     name: Publish storybook to chromatic 🧪
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: example
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: 12.x
       - run: npx yarn bootstrap
-        working-directory: example
       - uses: chromaui/action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Assuming you're trying to set the working-directory for the `npx yarn bootstrap` command, this is how you set the working directory.

Ref - https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-1